### PR TITLE
Ignore Claude Code scheduled task lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Claude Code session-local scheduled task lock (session-specific, not for sharing)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

`.claude/scheduled_tasks.lock` は Claude Code の ScheduleWakeup/loop 機能が同時実行防止用に作成するセッションローカルなロックファイルで、セッション ID と PID を含むためコミット対象にすべきでない。

`.claude/` ディレクトリ全体ではなく当該ファイルのみを ignore 対象として、将来この配下に置く可能性のあるプロジェクト用 agent 定義や設定ファイルは通常どおり git で管理できるようにする。

## 動作確認

- `git check-ignore -v .claude/scheduled_tasks.lock` → マッチ
- `.claude/` に他のファイルを置くと `Untracked files` として表示される(ignore されない)

## Test plan

- [ ] main へマージ後、`git status` に `.claude/scheduled_tasks.lock` が現れないことを確認
- [ ] 他の `.claude/` 配下ファイルを追加した際、untracked として検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)