### PR TITLE
Add label setup script for derived projects (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ npx markdownlint-cli2 "**/*.md"
 lychee --offline --include-fragments './**/*.md'
 ```
 
+## 派生プロジェクトでの初期セットアップ
+
+派生プロジェクトで Issue テンプレート(問題報告 PRB / 変更要求 CR)を運用する場合、テンプレートの `labels` frontmatter で参照される GitHub ラベルが事前に存在する必要があります(未登録だと `gh issue create --label ...` がエラー終了)。リポジトリ作成直後に以下を実行してください。
+
+```bash
+./scripts/setup_labels.sh                   # カレントディレクトリのリポジトリに作成
+./scripts/setup_labels.sh -R owner/repo     # 別リポジトリを指定
+```
+
+作成されるラベル:
+
+| ラベル | 色 | 用途 |
+|-------|----|------|
+| `change-request` | `#0366d6` | 変更要求(SCMP / CCB に基づく)|
+| `problem-report` | `#d73a4a` | 問題報告(SPRP に基づく)|
+
+`gh` CLI(認証済み)が必要です。スクリプトは冪等に動作し、既存ラベルは色・説明を更新します。
+
 ## 関連規格
 
 | 規格 | 用途 |

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# IEC 62304 テンプレート運用で参照される GitHub ラベルを冪等に作成・更新する。
+#
+# 背景: Issue テンプレート(.github/ISSUE_TEMPLATE/*.md)の labels frontmatter に
+# 指定したラベル本体がリポジトリに存在しないと、`gh issue create --label ...` が
+# エラー終了する。新規派生プロジェクト立ち上げ時の躓きを防ぐため、必須ラベルを
+# 一括作成する。
+#
+# 前提: gh CLI が利用可能で、対象リポジトリに対して認証済みであること。
+# 対象リポジトリは引数 -R で指定可能(指定しない場合はカレントディレクトリの
+# git origin が対象となる)。
+#
+# 使い方:
+#   ./scripts/setup_labels.sh                   # カレントリポジトリに作成
+#   ./scripts/setup_labels.sh -R owner/repo     # 別リポジトリを指定
+
+set -uo pipefail
+
+# ラベル定義: "name|color|description"
+labels=(
+  "change-request|0366d6|Change Request (CR) per SCMP/CCB"
+  "problem-report|d73a4a|Problem Report (PRB) per SPRP"
+)
+
+created=0
+updated=0
+failed=0
+
+for entry in "${labels[@]}"; do
+  IFS='|' read -r name color desc <<< "$entry"
+  if gh label create "$name" --color "$color" --description "$desc" "$@" >/dev/null 2>&1; then
+    echo "[created] $name"
+    created=$((created + 1))
+  elif gh label edit "$name" --color "$color" --description "$desc" "$@" >/dev/null 2>&1; then
+    echo "[updated] $name"
+    updated=$((updated + 1))
+  else
+    echo "[failed]  $name" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+echo
+echo "Summary: created=$created  updated=$updated  failed=$failed"
+[[ $failed -eq 0 ]]


### PR DESCRIPTION
## Summary

- Issue #7 への対応として、派生プロジェクトで Issue テンプレートを運用する際に必要な GitHub ラベル(`change-request` / `problem-report`)を一括作成する `scripts/setup_labels.sh` を同梱
- README に「派生プロジェクトでの初期セットアップ」セクションを追加し、スクリプトの使い方と作成されるラベル一覧を明記
- 本テンプレートには Issue テンプレート自体は同梱していない(これは Issue #7 のスコープ外、別 Issue で扱う)が、派生プロジェクトでテンプレートをコピー・運用する際に確実にラベルが揃うようにする

## 設計判断

- **冪等性**: 既存ラベルがあれば `gh label edit` で色・説明を更新する 2 段フォールバック構造とし、何度実行しても安全
- **対象指定**: 引数 `-R owner/repo` を `gh` コマンドにそのまま渡し、カレントディレクトリ以外も対象にできる
- **失敗時の終了コード**: 1 件でも作成・更新失敗があれば非ゼロで終了(CI 連携を想定)
- **ラベル選定**: Issue #7 提案にある `change-request` / `problem-report` のみを必須とし、`enhancement` 等の GitHub デフォルトラベルは含めない(既存の説明文を上書きしないため)

## 動作確認

`grace2riku/iec62304_template` リポジトリに対して 2 回実行し、created → updated の両パスを確認済み:

```
[created] change-request
[created] problem-report
Summary: created=2  updated=0  failed=0

# (再実行)
[updated] change-request
[updated] problem-report
Summary: created=0  updated=2  failed=0
```

## Closes

Closes #7

## Test plan

- [ ] CI(`docs-check.yml`)が全て通過すること
- [ ] `./scripts/setup_labels.sh -R <test-repo>` で 2 ラベルが作成されること(初回)
- [ ] 同コマンド再実行で `[updated]` 表示・終了コード 0 になること(冪等性)
- [ ] `bash -n scripts/setup_labels.sh` が構文エラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
