### PR TITLE
Document gh default repo pitfall for derived projects (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ lychee --offline --include-fragments './**/*.md'
 
 ## 派生プロジェクトでの初期セットアップ
 
+### 1. `gh` のデフォルトリポジトリ設定(重要)
+
+本テンプレートを `git clone` → `.git` 削除 → `git init` → 新リポジトリとして派生運用する場合や、`upstream` リモートを残してフォーク運用する場合、`gh` コマンドのデフォルトリポジトリ解決が **upstream(本テンプレート側)を向いてしまう** ことがあります。この状態で `gh issue view 1` や `gh run list` を実行すると、本来見たい派生リポジトリではなく upstream の情報が返り、CI 状態や Issue 状況の **誤認に直結** します(監査時に「CI が通っていない」と誤判定する事故事例あり)。
+
+リポジトリ作成直後に、以下のいずれかを徹底してください。
+
+**(推奨)デフォルトリポジトリを明示的に固定する:**
+
+```bash
+gh repo set-default <owner>/<your-derived-repo>
+```
+
+**または、すべての `gh` コマンドで `--repo`(`-R`)を明示する:**
+
+```bash
+gh issue list  --repo <owner>/<your-derived-repo>
+gh run list    --repo <owner>/<your-derived-repo>
+gh pr checks N --repo <owner>/<your-derived-repo>
+```
+
+CI 状態の確認は特に誤認の影響が大きいため、`gh run list --repo <自リポジトリ>` を必ず明示することを推奨します。
+
+### 2. GitHub ラベルの作成
+
 派生プロジェクトで Issue テンプレート(問題報告 PRB / 変更要求 CR)を運用する場合、テンプレートの `labels` frontmatter で参照される GitHub ラベルが事前に存在する必要があります(未登録だと `gh issue create --label ...` がエラー終了)。リポジトリ作成直後に以下を実行してください。
 
 ```bash


### PR DESCRIPTION
## Summary

- Issue #8 への対応として、派生運用フロー(`git clone` → `.git` 削除 → `git init`、または `upstream` リモート残しのフォーク)で `gh` のデフォルトリポジトリ解決が upstream(本テンプレート側)を向いてしまう **事故防止** を README に明記
- 監査時に CI 状態を誤認する **深刻な影響**(派生プロジェクトで 2 度再発)があるため、優先度 High の対応
- 「派生プロジェクトでの初期セットアップ」セクションを 2 段構成に整理し、`gh repo set-default` 設定を **最上段(1.)** に配置

## 変更内容

`README.md` の「派生プロジェクトでの初期セットアップ」セクションに以下を追加:

### 新規サブセクション「1. `gh` のデフォルトリポジトリ設定(重要)」

- 事故事例(CI 状態を誤判定)と発生条件(upstream リモート残し)を説明
- 推奨対策: `gh repo set-default <owner>/<your-derived-repo>`
- 代替対策: 全コマンドで `--repo` / `-R` を明示
- CI 確認時(`gh run list`)の `--repo` 必須を強調

### 既存サブセクション「2. GitHub ラベルの作成」

- 見出し階層を H2 → H3 に変更(セクション再構成のため)

## Closes

Closes #8

## Test plan

- [ ] CI(`docs-check.yml`)が全て通過すること
- [ ] README プレビューで 2 段構成の見出し階層が正しく表示されること
- [ ] 派生プロジェクトで `gh repo set-default` 実行後、`gh run list`(`--repo` なし)が派生リポジトリの結果を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
