### PR TITLE
Add branch protection setup script and CI failure guidance (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ CI 状態の確認は特に誤認の影響が大きいため、`gh run list --re
 
 `gh` CLI(認証済み)が必要です。スクリプトは冪等に動作し、既存ラベルは色・説明を更新します。
 
+### 3. CI 必須チェックの設定(Branch Protection)
+
+**安全クリティカルなクラス C 開発では、CI 失敗を放置したまま次ステップへ進行することは監査時のプロセス外進行リスク** となります(派生プロジェクトで軽微な lint エラーを 5 ステップ連続で見落とした事例あり)。`docs-check.yml` を Branch Protection Rule の required status checks に登録し、**CI が通らない限り PR をマージできない状態** にしてください。
+
+GitHub CLI が admin 権限で認証済みであれば、以下を実行するだけで設定できます。
+
+```bash
+./scripts/setup_branch_protection.sh                 # カレントリポジトリの main
+./scripts/setup_branch_protection.sh -R owner/repo   # 別リポジトリを指定
+./scripts/setup_branch_protection.sh -b develop      # 別ブランチを指定
+```
+
+このスクリプトは `docs-check.yml` の 4 ジョブ(構造・lint・リンク・日付書式)を必須チェックとして登録し、`main` への force push / 削除を禁止します。ソロ開発・小規模チームでも使えるよう、PR レビュー必須化と管理者への強制適用は **行いません**(必要に応じて GitHub Web UI で追加してください)。
+
+**手動で設定したい場合:** `Settings` → `Branches` → `Add rule` → `Branch name pattern: main` →「Require status checks to pass before merging」で上記 4 ジョブを指定してください。
+
+### 4. CI 失敗時の運用ルール(推奨)
+
+- CI 失敗は **次ステップ進行前に必ず修正** する(原因切り分け、該当ドキュメントの修正、再 push)
+- 複数ステップに渡る長期放置は、監査時に「プロセス外進行」と指摘されるリスクがある
+- `gh pr checks <PR番号>` / `gh run list --limit 5` で定期的に CI 状態を確認する
+- Slack / Microsoft Teams / メール通知を組織ごとに設定する(GitHub 公式 [notification docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs) 参照)
+
 ## 関連規格
 
 | 規格 | 用途 |

--- a/scripts/setup_branch_protection.sh
+++ b/scripts/setup_branch_protection.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# main ブランチに docs-check の必須ステータスチェックを設定する。
+#
+# 背景: CI(`.github/workflows/docs-check.yml`)が失敗していても気付かずに
+# 次ステップへ進行してしまう問題を防ぐ。安全クリティカルなクラス C 開発では
+# CI 失敗の放置は監査時のプロセス外進行リスクとなるため、Branch Protection
+# Rule で `docs-check` ジョブを required status checks に登録し、PR の
+# マージを物理的にブロックする。
+#
+# 設定内容:
+# - required_status_checks: docs-check.yml の 4 ジョブを必須化(strict mode)
+# - allow_force_pushes / allow_deletions: false
+# - enforce_admins: false(緊急ホットフィックス用に管理者は除外可)
+# - required_pull_request_reviews: null(ソロ開発を想定し PR レビュー必須化はしない)
+#
+# 前提: gh CLI が利用可能で、対象リポジトリへの admin 権限を持つこと。
+#
+# 使い方:
+#   ./scripts/setup_branch_protection.sh                     # カレントの main
+#   ./scripts/setup_branch_protection.sh -R owner/repo       # 別リポジトリ
+#   ./scripts/setup_branch_protection.sh -b develop          # 別ブランチ
+
+set -uo pipefail
+
+REPO=""
+BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R|--repo)   REPO="$2";   shift 2 ;;
+    -b|--branch) BRANCH="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" || {
+    echo "[error] -R で対象リポジトリを指定するか、git リポジトリ内で実行してください" >&2
+    exit 1
+  }
+fi
+
+echo "Applying branch protection: $REPO@$BRANCH"
+
+gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Verify IEC 62304 directory structure",
+      "Markdown lint",
+      "Internal link check",
+      "Date format policy"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+
+echo "Branch protection applied: $REPO@$BRANCH"


### PR DESCRIPTION
## Summary

- Issue #9 への対応として、CI 失敗の長期放置を **物理的にブロックする仕組み** と **運用ルール** を提供
- 安全クリティカルなクラス C 開発で、CI 失敗を見落として次ステップへ進行することは監査時の「プロセス外進行」リスクとなる(派生プロジェクトで軽微な lint エラーを 5 ステップ連続見落とした事例あり)

## 提供する対策

### 1. `scripts/setup_branch_protection.sh`(新規)

GitHub CLI 経由で Branch Protection Rule を一括設定するスクリプト:

- **必須ステータスチェック**: `docs-check.yml` の 4 ジョブ(構造 / Markdown lint / リンク / 日付書式)
- **force push / 削除禁止**
- **strict mode**(マージ前にベースブランチと同期必須)
- **PR レビュー必須化・管理者強制適用は行わない**(ソロ開発を想定、必要なら GitHub UI で追加)
- 引数: `-R owner/repo`、`-b branch` で対象指定可能

### 2. `README.md` — 「派生プロジェクトでの初期セットアップ」を 2 項目追加

- **§3 CI 必須チェックの設定(Branch Protection)**: 上記スクリプトの使い方と手動設定手順
- **§4 CI 失敗時の運用ルール(推奨)**: 次ステップ進行前修正の原則、`gh pr checks` による定期確認、通知設定参考リンク

## 設計判断

- **(b) Slack / メール通知サンプル提供**: 組織依存が大きく具体的な実装を書けないため、公式 notification docs への参考リンクのみ
- **(c)+(d) Branch Protection + スクリプト**: 最も効果的(マージを物理的にブロック)かつ一貫運用可能
- **PR レビュー必須化を外した理由**: Issue #9 の目的は「CI 失敗の放置防止」であり、レビュー必須化はスコープ外。ソロ・小規模チームで詰まらないようにデフォルト無効とし、組織ポリシーに応じて追加できるようにした

## 動作確認

- `bash -n scripts/setup_branch_protection.sh` 構文チェック通過
- **実環境での動作確認は未実施**(Branch Protection 適用は共有状態を変更するため、PR マージ後にユーザー確認のうえ実行想定)
- 本 PR のマージ後、本リポジトリ(`grace2riku/iec62304_template`)でスクリプトを実行するか、ユーザーに確認予定

## Closes

Closes #9

## Test plan

- [ ] CI(`docs-check.yml`)が全て通過すること
- [ ] `bash -n scripts/setup_branch_protection.sh` が構文エラーなく完了すること
- [ ] マージ後、本リポジトリへのスクリプト実行で main ブランチに 4 ジョブの必須チェックが登録されること
- [ ] その後、意図的に CI 失敗を含む PR を作成 → マージボタンがブロックされることを確認(オプション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
