### PR TITLE
Add CIL self-reference row and update checklist (#12)

### DIFF
--- a/8_software_configuration_management_process/configuration_item_list.md
+++ b/8_software_configuration_management_process/configuration_item_list.md
@@ -49,6 +49,7 @@
 | CI-DOC-SCMP | ソフトウェア構成管理計画書 | `8_software_configuration_management_process/` | {{v}} | 承認済 |
 | CI-DOC-CCB | CCB 運用規程 | `8_software_configuration_management_process/` | {{v}} | 承認済 |
 | CI-DOC-CRR | 変更要求台帳 | `8_software_configuration_management_process/` | {{v}} | 承認済 |
+| CI-DOC-CIL | 構成アイテム一覧(本書、自己参照) | `8_software_configuration_management_process/` | {{v}} | 承認済 |
 | CI-DOC-SPRP | ソフトウェア問題解決手順書 | `9_software_problem_resolution_process/` | {{v}} | 承認済 |
 | CI-DOC-ACL | IEC 62304 監査チェックリスト | `compliance/` | {{v}} | 承認済 |
 
@@ -99,3 +100,14 @@
 | バージョン | 日付 | 変更内容 | 変更者 |
 |----------|------|---------|--------|
 | 0.1 | {{YYYY-MM-DD}} | 初版作成 | {{氏名}} |
+
+## 付録 A: CIL 更新時チェックリスト
+
+CIL を更新する際は、以下の順序で **全走査** すること。「今回変更する CI」だけに注力すると、自己参照(CI-DOC-CIL)や過去ステップで完成済みだが未反映の CI が漏れやすい。
+
+- [ ] 今回の CR で直接変更する CI の現行バージョン・状態を更新した
+- [ ] **自己参照(CI-DOC-CIL)の現行バージョンと状態を、本 CIL 自身の昇格後バージョンに更新した**
+- [ ] 過去ステップで完成したが CIL に未反映の CI(ソースコード・ドキュメント・SOUP・ツール・試験資産・成果バイナリ)が無いか §3〜§8 を全走査した
+- [ ] ベースライン履歴(§9)への追加が必要か判定し、必要なら追記した
+- [ ] 改訂履歴(§10)に今回の昇格エントリを追加した
+- [ ] 関連する CRR のエントリ・CCB 議事録と CI バージョンが整合していることを確認した


### PR DESCRIPTION
## Summary

- Issue #12 への対応として、CIL テンプレートに **自己参照行** と **更新時の全走査チェックリスト** を追加し、派生プロジェクトで発生した 3 件の更新漏れ(SAD 状態未更新、CCB 状態未更新、自己参照バージョン未更新)と同種の事故を再発防止する
- 本テンプレートの現状を確認したところ、§4 ドキュメント表に SCMP / CCB / CRR / SPRP 等は含まれているが **CI-DOC-CIL(自身)が欠落** していた。派生側が独自追加した際の手間と漏れリスクを一次側で解消する

## 変更内容

### 1. §4 ドキュメント表に CI-DOC-CIL を追加

```
| CI-DOC-CRR  | 変更要求台帳 | ...
+ CI-DOC-CIL  | 構成アイテム一覧(本書、自己参照) | ...
| CI-DOC-SPRP | ソフトウェア問題解決手順書 | ...
```

「本書、自己参照」と明記することで、更新時に意識しやすくする。

### 2. 付録 A「CIL 更新時チェックリスト」を新設

Issue #12 提案に本テンプレートでの経路参照(§3〜§8、§9、§10、CRR、CCB)を補って 6 項目化:

- [ ] 今回の CR で直接変更する CI の現行バージョン・状態を更新した
- [ ] **自己参照(CI-DOC-CIL)の現行バージョンと状態を、本 CIL 自身の昇格後バージョンに更新した**
- [ ] 過去ステップで完成したが CIL に未反映の CI(ソースコード・ドキュメント・SOUP・ツール・試験資産・成果バイナリ)が無いか §3〜§8 を全走査した
- [ ] ベースライン履歴(§9)への追加が必要か判定し、必要なら追記した
- [ ] 改訂履歴(§10)に今回の昇格エントリを追加した
- [ ] 関連する CRR のエントリ・CCB 議事録と CI バージョンが整合していることを確認した

## Closes

Closes #12

## Test plan

- [ ] CI(`docs-check.yml`)が全て通過すること(Branch Protection の required checks を通過)
- [ ] `npx markdownlint-cli2@0.13.0 "**/*.md"` がローカルで 0 エラー(実行確認済)
- [ ] 派生プロジェクトでチェックリストを運用し、自己参照・未反映 CI の漏れが実際に減ることを次回 CIL 昇格時にレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)
