### PR TITLE
Ignore Claude Code per-developer settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Claude Code session-local scheduled task lock (session-specific, not for sharing)
 .claude/scheduled_tasks.lock
+
+# Claude Code user-local settings (per-developer, not for sharing)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- `.claude/settings.local.json` (Claude Code のユーザごとローカル設定ファイル) を `.gitignore` に追加
- 既存の `.claude/scheduled_tasks.lock` 登録と同じ流儀(個別ファイル指定)で追加し、他のコントリビュータの個人設定が共有履歴に漏れないようにする

## 変更内容

```diff
 # Claude Code session-local scheduled task lock (session-specific, not for sharing)
 .claude/scheduled_tasks.lock
+
+# Claude Code user-local settings (per-developer, not for sharing)
+.claude/settings.local.json
```

## Test plan

- [x] `git check-ignore -v .claude/settings.local.json` が `.gitignore:5:.claude/settings.local.json` を返すこと
- [x] `git status` で `.claude/` が Untracked に表示されないこと
- [ ] CI(`docs-check.yml`)が全て通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)